### PR TITLE
Changed the hardcoded React version to ^15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     ]
   },
   "dependencies": {
-    "react": "15.4.2"
+    "react": "^15.0.0"
   }
 }


### PR DESCRIPTION
It is not good to hardcode the React version, especially when the library works good with React 15.0.0.

By the way, it fixes #28 for those, who are using React !== 15.4.2.